### PR TITLE
Add more instructions on how to install the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,60 @@ Vim plugin for GitHub
 ## Installation
 Please install `curl` before installtion.
 
+After you have installed `curl`, you can add this repo using your favorite plugin manager.
+
+### dein.vim
+
+Using [dein.vim](https://github.com/Shougo/dein.vim) add this to your config:
+
 ```toml
 [[plugin]]
 repo = 'skanehira/gh.vim'
+```
+
+### vim-plug
+
+Using [vim-plug](https://github.com/junegunn/vim-plug/blob/master/README.md), add the following to your vimrc:
+
+```vim
+call plug#begin('~/.vim/plugged')
+Plug 'skanehira/gh.vim'
+call plug#end()
+```
+
+### Vundle
+
+Using [Vundle](https://github.com/VundleVim/Vundle.vim), add the following to your vimrc:
+
+```vim
+set nocompatible
+filetype off
+
+set rtp+=~/.vim/bundle/Vundle.vim
+
+call vundle#begin()
+Plugin 'VundleVim/Vundle.vim'
+Plugin 'skanehira/gh.vim'
+call vundle#end()
+
+filetype plugin indent on
+```
+
+### pathogen
+
+Using [pathogen](https://github.com/tpope/vim-pathogen) add the following to your vimrc:
+
+```vim
+execute pathogen#infect()
+syntax on
+filetype plugin indent on
+```
+
+And install the plugin like this:
+
+```sh
+cd ~/.vim/bundle && \
+git clone https://github.com/skanehira/gh.vim
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -33,41 +33,6 @@ Plug 'skanehira/gh.vim'
 call plug#end()
 ```
 
-### Vundle
-
-Using [Vundle](https://github.com/VundleVim/Vundle.vim), add the following to your vimrc:
-
-```vim
-set nocompatible
-filetype off
-
-set rtp+=~/.vim/bundle/Vundle.vim
-
-call vundle#begin()
-Plugin 'VundleVim/Vundle.vim'
-Plugin 'skanehira/gh.vim'
-call vundle#end()
-
-filetype plugin indent on
-```
-
-### pathogen
-
-Using [pathogen](https://github.com/tpope/vim-pathogen) add the following to your vimrc:
-
-```vim
-execute pathogen#infect()
-syntax on
-filetype plugin indent on
-```
-
-And install the plugin like this:
-
-```sh
-cd ~/.vim/bundle && \
-git clone https://github.com/skanehira/gh.vim
-```
-
 ## Usage
 Set your personal access token.
 


### PR DESCRIPTION
I was honestly a bit confused about the installation instructions, since I don't use `dein.vim`, which these instructions seem to assume.

This can probably be confusing for newer vim users, that would just paste the `toml`-config in their vimrc.

I've added some more context for dein.vim, and provided instructions for a couple of other plugin managers.