### PR TITLE
Link to the personal access token-page from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ call plug#end()
 ```
 
 ## Usage
-Set your personal access token.
+Set your [personal access token](https://github.com/settings/tokens).
 
 ```vim
 let g:gh_token = 'xxxxxxxxxxxxxxxxxxxx'


### PR DESCRIPTION
Without making the README any longer, I think this solve an issue I ran into myself: had to do a Google search for the GitHub _personal access token page_.

This is a really small PR, it just links the text "personal access token" to the relevant page.