### PR TITLE
fix: cannot input issue title when new issue buffer is already exists #71

### DIFF
--- a/autoload/gh/issues.vim
+++ b/autoload/gh/issues.vim
@@ -189,14 +189,6 @@ function! gh#issues#list() abort
 endfunction
 
 function! gh#issues#new() abort
-  let s:gh_issue_title = input('[gh.vim] issue title ')
-  echom ''
-  redraw
-  if s:gh_issue_title is# ''
-    call gh#gh#error_message('no issue title')
-    bw!
-    return
-  endif
 
   let s:gh_issues_new_bufid = bufnr()
   call gh#gh#init_buffer()
@@ -237,7 +229,6 @@ function! s:create_issue() abort
 endfunction
 
 function! s:create_issue_success(resp) abort
-  call gh#gh#delete_buffer(s:, 'gh_issues_new_bufid')
   bw!
   redraw!
   if has_key(g:, 'gh_open_issue_on_create') && g:gh_open_issue_on_create is# 1
@@ -247,6 +238,14 @@ function! s:create_issue_success(resp) abort
 endfunction
 
 function! s:set_issue_template_buffer(resp) abort
+  let s:gh_issue_title = input('[gh.vim] issue title ')
+  echom ''
+  redraw
+  if s:gh_issue_title is# ''
+    call gh#gh#error_message('no issue title')
+    return
+  endif
+
   call execute(printf('e gh://%s/%s/issues/%s', s:gh_issue_new.owner, s:gh_issue_new.name, s:gh_issue_title))
   call gh#map#apply('gh-buffer-issue-new', bufnr())
   setlocal buftype=acwrite
@@ -273,6 +272,7 @@ endfunction
 
 function! s:open_template_list(files) abort
   if empty(a:files)
+    bw!
     call s:set_issue_template_buffer({'body': ''})
     return
   endif

--- a/autoload/gh/issues.vim
+++ b/autoload/gh/issues.vim
@@ -237,6 +237,7 @@ function! s:create_issue() abort
 endfunction
 
 function! s:create_issue_success(resp) abort
+  call gh#gh#delete_buffer(s:, 'gh_issues_new_bufid')
   bw!
   redraw!
   if has_key(g:, 'gh_open_issue_on_create') && g:gh_open_issue_on_create is# 1


### PR DESCRIPTION
#71
added deletion of `gh://:owner/:repo/:branch/issues/new` buffer just after creating new issue.
by this fix, I could confirm that this issue doesn't happen no more.