### PR TITLE
issues: Obsolete branch specification when creating #83

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ currently `gh.vim` provides buffers is bellow.
 |-----------------------------------------------------------|------------------------------------|
 | `gh://:owner/:repo/issues[?state=open&..]`                | issue list                         |
 | `gh://:owner/:repo/issues/:number`                        | edit issue                         |
-| `gh://:owner/:repo/:branch/issues/new`                    | new issue                          |
+| `gh://:owner/:repo/issues/new`                            | new issue                          |
 | `gh://:owner/:repo/issues/:number/comments[?page=1&..]`   | issue comment list                 |
 | `gh://:owner/:repo/issues/:number/comments/new`           | new issue comment                  |
 | `gh://:owner/repos`                                       | repository list                    |

--- a/autoload/gh/gh.vim
+++ b/autoload/gh/gh.vim
@@ -28,7 +28,7 @@ function! gh#gh#init() abort
     call gh#issues#list()
   elseif bufname =~# '^gh:\/\/[^/]\+\/[^/]\+\/issues\/[0-9]\+$'
     call gh#issues#issue()
-  elseif bufname =~# '^gh:\/\/[^/]\+\/[^/]\+\/.\+\/issues\/new$'
+  elseif bufname =~# '^gh:\/\/[^/]\+\/[^/]\+\/issues\/new$'
     call gh#issues#new()
   elseif bufname =~# '^gh:\/\/[^/]\+\/[^/]\+\/issues\/\d\+\/comments$'
         \ || bufname =~# '^gh:\/\/[^/]\+\/[^/]\+\/issues\/\d\+\/comments?\+'

--- a/autoload/gh/github/repos.vim
+++ b/autoload/gh/github/repos.vim
@@ -51,3 +51,12 @@ function! gh#github#repos#create(data) abort
         \ }
   return gh#http#request(settings)
 endfunction
+
+function! gh#github#repos#get_repo(owner, repo) abort
+  let url = printf('https://api.github.com/repos/%s/%s', a:owner, a:repo)
+  let settings = {
+        \ 'method': 'GET',
+        \ 'url': url,
+        \ }
+  return gh#http#request(settings)
+endfunction

--- a/autoload/gh/github/repos.vim
+++ b/autoload/gh/github/repos.vim
@@ -54,9 +54,5 @@ endfunction
 
 function! gh#github#repos#get_repo(owner, repo) abort
   let url = printf('https://api.github.com/repos/%s/%s', a:owner, a:repo)
-  let settings = {
-        \ 'method': 'GET',
-        \ 'url': url,
-        \ }
-  return gh#http#request(settings)
+  return gh#http#get(url)
 endfunction

--- a/autoload/gh/issues.vim
+++ b/autoload/gh/issues.vim
@@ -196,15 +196,15 @@ function! gh#issues#new() abort
 
   let m = matchlist(bufname(), 'gh://\(.\{-}\)/\(.\{-}\)/issues/new$')
 
-  let l:owner = m[1]
-  let l:repo = m[2]
+  let owner = m[1]
+  let repo = m[2]
   let s:gh_issue_new = {
-        \ 'owner': l:owner,
-        \ 'name': l:repo,
+        \ 'owner': owner,
+        \ 'name': repo,
         \ 'branch': '',
         \ }
 
-  call gh#github#repos#get_repo(l:owner, l:repo)
+  call gh#github#repos#get_repo(owner, repo)
         \.then(function('s:set_default_branch'))
         \.then({-> gh#github#repos#files(s:gh_issue_new.owner, s:gh_issue_new.name, s:gh_issue_new.branch)})
         \.then(function('s:get_template_files'))

--- a/autoload/gh/issues.vim
+++ b/autoload/gh/issues.vim
@@ -201,7 +201,7 @@ function! gh#issues#new() abort
   let s:gh_issue_new = {
         \ 'owner': owner,
         \ 'name': repo,
-        \ 'branch': '',
+        \ 'branch': 'main',
         \ }
 
   call gh#github#repos#get_repo(owner, repo)
@@ -214,11 +214,10 @@ function! gh#issues#new() abort
 endfunction
 
 function! s:set_default_branch(resp)
-  if !has_key(a:resp.body, 'default_branch')
-    call gh#gh#error_message('not found default branch')
-    return
+  if has_key(a:resp.body, 'default_branch')
+    " set default branch name, otherwise use 'main' as default branch name.
+    let s:gh_issue_new.branch = a:resp.body['default_branch']
   endif
-  let s:gh_issue_new.branch = a:resp.body['default_branch']
 endfunction
 
 function! s:get_template_error(error) abort


### PR DESCRIPTION
## 💪 Summary
fix the issue #83 .
- add getting default branch function
- and set it to `s:gh_issue_new.branch`

## 🏁 Goals
- to be able to create new issue by following command. (removed branch name)
```
:e gh://:owner/:repo/issues/new
```

