### PR TITLE
fix cannot save bookmark when file is not exists #114

### DIFF
--- a/autoload/gh/bookmark.vim
+++ b/autoload/gh/bookmark.vim
@@ -44,10 +44,8 @@ endfunction
 
 function! s:bookmark_file_update() abort
   try
-    if filewritable(s:gh_bookmark_file)
-      let lines = getbufline(s:gh_bookmark_list_bufid, 1, '$')
-      call writefile(lines, s:gh_bookmark_file)
-    endif
+    let lines = getbufline(s:gh_bookmark_list_bufid, 1, '$')
+    call writefile(lines, s:gh_bookmark_file)
     setlocal nomodified
   catch
     call gh#gh#message(v:exception)


### PR DESCRIPTION
# 💪 Summary
fixed $114

## 🏁 Goals
Can save bookmark when `~/.gh-bookmark` is not exists
