### PR TITLE
remove white space in autoload/gh/issues.vim

### DIFF
--- a/autoload/gh/issues.vim
+++ b/autoload/gh/issues.vim
@@ -38,7 +38,7 @@ function! s:edit_issue() abort
 endfunction
 
 function! s:format_assignees(assignees) abort
-  if len(a:assignees) > 0 
+  if len(a:assignees) > 0
     let users = a:assignees
     let result = ''
     if len(a:assignees) > 2


### PR DESCRIPTION
## 💪 Summary
simple fix.
- remove white space in autoload/gh/issues.vim

## 🏁 Goals
remove white space in autoload/gh/issues.vim

